### PR TITLE
Implement recursive search for folder

### DIFF
--- a/download_from_drive.py
+++ b/download_from_drive.py
@@ -81,6 +81,8 @@ def folder_upload(service):
     parents_id = {}
 
     for root, _, files in os.walk(FULL_PATH, topdown=True):
+        # This has problem on windows, recommend using os.path.sep as the windows
+        # uses "\\" (Escape character "\") as separator
         last_dir = root.split('/')[-1]
         pre_last_dir = root.split('/')[-2]
         if pre_last_dir not in parents_id.keys():
@@ -121,18 +123,23 @@ def check_upload(service):
 
     """
 
-    results = service.files().list(
-        pageSize=100,
-        q="'root' in parents and trashed != True and \
-        mimeType='application/vnd.google-apps.folder'").execute()
+    search_list = ['root'] # All IDs to be searched recursively
+    is_found = False
 
-    items = results.get('files', [])
-
-    # Check if folder exists, and then create it or get this folder's id.
-    if DIR_NAME in [item['name'] for item in items]:
-        folder_id = [item['id']for item in items
-                     if item['name'] == DIR_NAME][0]
-    else:
+    for search_id in search_list:
+        results = service.files().list(
+            pageSize=100,
+            q="%r in parents and trashed != True and mimeType='application/vnd.google-apps.folder'" % search_id
+        ).execute()
+        items = results.get('files', [])
+        for item in items:
+            if [ord(c) for c in item['name']]==[ord(c) for c in DIR_NAME]:
+                is_found = True
+                folder_id = item['id']
+                break
+            else:
+                search_list.append(item['id'])
+    if not is_found:
         parents_id = folder_upload(service)
         folder_id = parents_id[DIR_NAME]
 
@@ -331,7 +338,7 @@ def main():
 
         results = service.files().list(
             pageSize=1000,
-            q=('%r in parents and \
+            q=('%r in parents and trashed != True and  \
             mimeType!="application/vnd.google-apps.folder"' % folder_id),
             fields="files(id, name, mimeType, \
                 modifiedTime, md5Checksum)").execute()


### PR DESCRIPTION
The original folder search only searches the Drive folder on root, and generates one in root if not found. This changes enables you to search the folder with exact name recursively and only when the folder on the exhaustive search isn't found, it will fall back into making one in the root. The comparison between two strings also changed into comparing two lists of char integer ord() equivalent sequences due to strange behavior of comparing the strings directly which can return false even if the string is exactly the same.

This also includes a reminder that string split using "/" sometimes don't work as windows uses "\\", and a little change of the Drive API Query to make sure it looks only for the file that are not trashed in Drive, often times prior to this change it will download trashed files too to local.

Also, a small note that Drive always has wrong timestamp for some reason, it's always hours late compared to the actual time the file got uploaded.